### PR TITLE
allow specifying different values for IOS bundle and display names, adds acknowledgements to flutter_launcher_icons Fixes #27 and #28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Changelog
+
+## 1.0.3
+
+* Add ability to specify the "iosBundleDisplayName" separate from the "appName"
+* Add ability to specify the "iosBundleIdentifier" separate from the "packageName"
+* Add acknowledgement section to the README.md file to acknowledge that all of the flutter launcher icon code originated
+  from the flutter_launcher_icon package.
+
 ## 1.0.2
 
 * iOS: Updates CFBundleDisplayName in pbxproj file if exist

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 ## Features
 
 - **Package Name Update**: Automatically updates the package name for both Android and iOS.
-- **Launcher Icon Update**: Replaces the app’s launcher icon with a new one, updating for both platforms.
 - **App Name Update**: Changes the app name that is displayed on the device.
 - **Directory Structure Refactoring**: Moves the `MainActivity` to the correct new package directory and deletes the old one.
 - **iOS Bundle Identifier Update**: Updates the iOS product bundle identifier (`Runner.xcodeproj`).
+- **Launcher Icon Update**: Replaces the app’s launcher icon with a new one, updating for both platforms.  Optional if flutter_launcher_icons package is not being used.
 
 
 ## What It does?
@@ -29,15 +29,19 @@ This package uses a configuration file (`rebrand.json`) to automatically apply a
 
 Create a file called `rebrand.json` in your Flutter project's root directory. This file should include the following keys with valid values:
 - `packageName`: The new package name (e.g., `com.newcompany.newapp`).
-- `launcherIconPath`: Path to the new launcher icon (e.g., `assets/icons/new_launcher_icon.png`).
+- `iosBundleIdentifier` Optional if IOS bundle identifier is different than the `packageName` on Android
 - `appName`: The new app name (e.g., `NewApp`).
+- `iosBundleDisplayName` Optional if the IOS bundle display name is different than the `appName` for android
+- `launcherIconPath`: Path to the new launcher icon (e.g., `assets/icons/new_launcher_icon.png`).  Do not specify if flutter_laucher_icons package is being used.
 
 ### Example `rebrand.json`:
 ```json
 {
-  "packageName": "com.newcompany.newapp",
-  "launcherIconPath": "assets/icons/new_launcher_icon.png",
-  "appName": "NewApp"
+  "packageName": "com.newcompany.newapp",         <<<< This changes the android <manfest package=XXXX > name and also BundleIdentifer unless "iosBundleIdentifier" is specified
+  "iosBundleIdentifier": "com.newcompany.newapp.BundleIDForIOS",   <<<< Optional if IOS bundle identifier is different than the "packageName" on Android
+  "appName": "NewApp",    <<< This changes the android:label in the AndroidManifest.xml (and BundleDisplayName on IOS if "iosBundleDisplayName" is not specified)
+  "iosBundleDisplayName": "NewBundleDisplayName",   <<<<< Optional if the IOS bundle display name is different than the "appName" on android
+  "launcherIconPath": "assets/icons/new_launcher_icon.png",   <<< DO NOT specify if flutter_launcher_icons package is being used
 }
 ```
 
@@ -47,7 +51,7 @@ Create a file called `rebrand.json` in your Flutter project's root directory. Th
 Add Flutter App Rebrand to your `pubspec.yaml` in `dev_dependencies:` section.
 ```yaml
 dev_dependencies: 
-  flutter_app_rebrand: ^1.0.0
+  flutter_app_rebrand: ^1.0.3
 ```
 or run this command
 ```bash
@@ -87,6 +91,10 @@ Distributed under the MIT license.
 3. Commit your changes with a descriptive message (`git commit -am 'Add new feature: your-feature-name''`)
 4. Push to the branch (`git push origin feature/your-feature-name`)
 5. Open a Pull Request and submit it for review.
+
+## Acknowledgements
+
+The launcher icon code within FAR was originally extracted from version XYZ of the [flutter_launcher_icon package](https://pub.dev/packages/flutter_launcher_icons).
 
 ## Support
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -13,42 +13,42 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   crypto:
     dependency: transitive
     description:
@@ -69,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -84,7 +84,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.1"
+    version: "1.0.2"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -110,18 +110,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -142,10 +142,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
@@ -158,18 +158,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   petitparser:
     dependency: transitive
     description:
@@ -182,55 +182,55 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.4"
   typed_data:
     dependency: transitive
     description:
@@ -251,10 +251,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
+    version: "15.0.0"
   xml:
     dependency: transitive
     description:
@@ -264,5 +264,5 @@ packages:
     source: hosted
     version: "6.5.0"
 sdks:
-  dart: ">=3.5.3 <4.0.0"
+  dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/flutter_app_rebrand.dart
+++ b/lib/flutter_app_rebrand.dart
@@ -47,9 +47,9 @@ class FlutterAppRebrand {
       assert(data[FARConstants.appNameKey] is String,
           FARConstants.appNameStringError);
       assert(data[FARConstants.iosBundleIdentifierNameKey]==null || (data[FARConstants.iosBundleIdentifierNameKey] is String),
-          FARConstants.launcherIconPathStringError);
+          FARConstants.iosBundleIdentifierNameKeyStringError);
       assert(data[FARConstants.iosBundleDisplayNameKey]==null || (data[FARConstants.iosBundleDisplayNameKey] is String),
-          FARConstants.launcherIconPathStringError);
+          FARConstants.iosBundleDisplayNameKeyStringError);
 
       // Extract fields from JSON
       final String newPackageName = data[FARConstants.packageNameKey];

--- a/lib/src/configs/android_rebrand.dart
+++ b/lib/src/configs/android_rebrand.dart
@@ -23,9 +23,9 @@ class AndroidRebrand {
     'mipmap-xxxhdpi'
   ];
 
-  Future<void> process(String newPackageName) async {
-    print("Running for android");
-    if (!await File(FARConstants.androidAppBuildGradle).exists()) {
+
+  Future<void> processBuildGradleFile(String newPackageName) async {
+     if (!await File(FARConstants.androidAppBuildGradle).exists()) {
       print(
           'ERROR:: build.gradle file not found, Check if you have a correct android directory present in your project'
           '\n\nrun " flutter create . " to regenerate missing files.');
@@ -46,11 +46,73 @@ class AndroidRebrand {
     var name = match.group(1);
     final String? oldPackageName = name;
 
-    print("Old Package Name: $oldPackageName");
+    print("Previous applicationId Package Name: $oldPackageName");
 
     print('Updating build.gradle File');
     await _replace(
         FARConstants.androidAppBuildGradle, newPackageName, oldPackageName);
+  }
+
+
+// In build.gradle.kts file WE MUST CHANGE BOTH namespace= and applicationId=
+Future<void> processBuildGradleFileKTS(String newPackageName) async {
+     if (!await File(FARConstants.androidAppBuildGradleKTS).exists()) {
+      print(
+          'ERROR:: build.gradle.kts file not found, Check if you have a correct android directory present in your project'
+          '\n\nrun " flutter create . " to regenerate missing files.');
+      return;
+    }
+    String? contents = await FileUtils.instance
+        .readFileAsString(FARConstants.androidAppBuildGradleKTS);
+
+    var regNamespace = RegExp(r'namespace\s*=?\s*"(.*)"',
+        caseSensitive: true, multiLine: false);
+    var matchNamespace = regNamespace.firstMatch(contents!);
+    if (matchNamespace == null) {
+      print('ERROR:: namespace not found in build.gradle.kts file, '
+          'Please file an issue on github with '
+          '${FARConstants.androidAppBuildGradleKTS} file attached.');
+      return;
+    }
+    var nameNamespace = matchNamespace.group(1);
+    final String? oldNamespacePackageName = nameNamespace;
+
+    print("Previous namespace Package Name: $oldNamespacePackageName");
+
+
+    // Now Do applicationId
+    var reg = RegExp(r'applicationId\s*=?\s*"(.*)"',
+        caseSensitive: true, multiLine: false);
+    var match = reg.firstMatch(contents!);
+    if (match == null) {
+      print('ERROR:: applicationId not found in build.gradle.kts file, '
+          'Please file an issue on github with '
+          '${FARConstants.androidAppBuildGradleKTS} file attached.');
+      return;
+    }
+    var name = match.group(1);
+    final String? oldPackageName = name;
+
+    print("Previous applicationId Package Name: $oldPackageName");
+
+    print('Updating build.gradle.kts File');
+    await _replace(
+        FARConstants.androidAppBuildGradleKTS, newPackageName, oldPackageName);
+  }
+
+  Future<void> process(String newPackageName) async {
+    print("Running for android");
+    if (await File(FARConstants.androidAppBuildGradle).exists()) {
+      processBuildGradleFile(newPackageName);
+    }
+
+    if (await File(FARConstants.androidAppBuildGradleKTS).exists()) {
+      processBuildGradleFileKTS(newPackageName);
+    }
+
+
+
+
 
     var mText = 'package="$newPackageName">';
     var mRegex = '(package=.*)';

--- a/lib/src/constants/far_constants.dart
+++ b/lib/src/constants/far_constants.dart
@@ -69,6 +69,7 @@ class FARConstants {
 
   /// Android Specific
   static const String androidAppBuildGradle = 'android/app/build.gradle';
+  static const String androidAppBuildGradleKTS = 'android/app/build.gradle.kts';
   static const String androidManifest =
       'android/app/src/main/AndroidManifest.xml';
   static const String androidDebugManifest =
@@ -108,12 +109,20 @@ class FARConstants {
   ];
 
   static const packageNameKey = 'packageName';
+  static const iosBundleIdentifierNameKey = 'iosBundleIdentifier';
   static const launcherIconPathKey = 'launcherIconPath';
   static const appNameKey = 'appName';
+  static const iosBundleDisplayNameKey = 'iosBundleDisplayName';
   static const rebrandFileKey = 'rebrand.json';
   static const packageNameStringError = 'Package name must be String';
   static const launcherIconPathStringError =
-      'Launcher Icon path must be String';
+      '${launcherIconPathKey} must be MISSING or be String';
+  static const iosBundleIdentifierNameKeyStringError =
+       '${iosBundleIdentifierNameKey} must be MISSING or be String';
+  static const iosBundleDisplayNameKeyStringError =
+      '${iosBundleDisplayNameKey} must be MISSING or be String';
+
+
   static const appNameStringError = 'App Name must be String';
 
   static const String version = 'version';


### PR DESCRIPTION
This PR adds the ability to specify IOS bundle and display names separately from the Android names. (or NOT for backwards compatibility)
It also adds acknowledgements to the readme that the code for launcher icons came from the [flutter_launcher_icons package](https://pub.dev/packages/flutter_launcher_icons) package.

It also adds support for build.gradle.kts files (which is the way flutter now makes gradle files).