### PR TITLE
flush all writes to prevent corruption from later reads of incomplete data Fixes #32

### DIFF
--- a/lib/src/configs/android_rebrand.dart
+++ b/lib/src/configs/android_rebrand.dart
@@ -257,6 +257,6 @@ Future<void> processBuildGradleFileKTS(String newPackageName) async {
         lines.add('');
       }
     }
-    androidManifestFile.writeAsString(lines.join('\n'));
+    androidManifestFile.writeAsString(lines.join('\n'),flush:true);
   }
 }

--- a/lib/src/configs/ios_rebrand.dart
+++ b/lib/src/configs/ios_rebrand.dart
@@ -68,7 +68,7 @@ class IoSRebrand {
     );
 
     // Write the updated content back to the file
-    await file.writeAsString(updatedContent);
+    await file.writeAsString(updatedContent,flush:true);
     print('Plist file updated successfully.');
 
     await makeChangesInPbxProj(name);

--- a/lib/src/icon_generators/android/android_icon_generator.dart
+++ b/lib/src/icon_generators/android/android_icon_generator.dart
@@ -68,7 +68,7 @@ class AndroidIconGenerator {
     final List<String> transformedLines =
         _transformAndroidManifestWithNewLauncherIcon(
             oldManifestLines, iconName);
-    await androidManifestFile.writeAsString(transformedLines.join('\n'));
+    await androidManifestFile.writeAsString(transformedLines.join('\n'),flush:true);
   }
 
   /// Updates only the line containing android:icon with the specified iconName

--- a/lib/src/icon_generators/iOS/ios_icon_generator.dart
+++ b/lib/src/icon_generators/iOS/ios_icon_generator.dart
@@ -110,7 +110,7 @@ class IoSIconGenerator {
     }
 
     final String entireFile = '${lines.join('\n')}\n';
-    await iOSConfigFile.writeAsString(entireFile);
+    await iOSConfigFile.writeAsString(entireFile,flush:true);
   }
 
   /// Create the Contents.json file
@@ -120,7 +120,7 @@ class IoSIconGenerator {
     File(newIconFolder).create(recursive: true).then((File contentsJsonFile) {
       final String contentsFileContent =
           generateContentsFileAsString(newIconName);
-      contentsJsonFile.writeAsString(contentsFileContent);
+      contentsJsonFile.writeAsString(contentsFileContent,flush:true);
     });
   }
 
@@ -131,7 +131,7 @@ class IoSIconGenerator {
     File(newIconFolder).create(recursive: true).then((File contentsJsonFile) {
       final String contentsFileContent =
           generateContentsFileAsString(newIconName);
-      contentsJsonFile.writeAsString(contentsFileContent);
+      contentsJsonFile.writeAsString(contentsFileContent,flush:true);
     });
   }
 

--- a/lib/src/utils/file_utils.dart
+++ b/lib/src/utils/file_utils.dart
@@ -40,7 +40,7 @@ class FileUtils {
 
   Future<void> writeFileFromString(String path, String contents) async {
     var file = File(path);
-    await file.writeAsString(contents);
+    await file.writeAsString(contents,flush:true);
   }
 
   Future<bool> rebrandJSONExist() async {


### PR DESCRIPTION
This PR modifies all `writeAsString()` calls to pass `flush:true` to guarantee that all future reads/writes of the files later in the programs execution are always getting the correct data and not causing any corruption.

AndroidManifest.xml was being corrupted when the `AndroidRebrand.instance.updateAppName()` was modifying the file after the `AndroidRebrand.instance.process()` function was called  (but it's async write was not complete because flush was not true).

